### PR TITLE
Added missing closing paren to example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ training = [
 dec_tree = DecisionTree::ID3Tree.new(labels, data, "not angry", color: :discrete, hunger: :continuous)
 dec_tree.train
 
-decision = dec_tree.predict([7, "red"]
+decision = dec_tree.predict([7, "red"])
 puts "Predicted: #{decision} ... True decision: #{test.last}";
 ```
 


### PR DESCRIPTION
Just a nit, fixes missing parenthesis typo.
