### PR TITLE
Swapping CR for NL character in decisiontree.rb

### DIFF
--- a/lib/decisiontree.rb
+++ b/lib/decisiontree.rb
@@ -1,1 +1,1 @@
-require File.dirname(__FILE__) + '/decisiontree/id3_tree.rb'
+require File.dirname(__FILE__) + '/decisiontree/id3_tree.rb'


### PR DESCRIPTION
The presence of this character doesn't cause any errors, just an annoying warning when using this gem with ruby 2: warning: encountered \r in middle of line, treated as a mere "space". 

I'm guessing it's either from an old Mac or a corrupted Windows crlf; in any case, no other files in this repo seem to have this issue.
