### PR TITLE
Follow Ruby Naming convention and Added an extra attributes accessor for training data

### DIFF
--- a/lib/decisiontree/id3_tree.rb
+++ b/lib/decisiontree/id3_tree.rb
@@ -133,8 +133,8 @@ module DecisionTree
       dgp.write_to_file("#{filename}.#{file_type}", file_type)
     end
 
-    def ruleset
-      rs = Ruleset.new(@attributes, @data, @default, @type)
+    def rule_set
+      rs = RuleSet.new(@attributes, @data, @default, @type)
       rs.rules = build_rules
       rs
     end
@@ -260,7 +260,7 @@ module DecisionTree
     end
   end
 
-  class Ruleset
+  class RuleSet
     attr_accessor :rules
 
     def initialize(attributes, data, default, type)
@@ -322,7 +322,7 @@ module DecisionTree
 
     def train(data = @data, attributes = @attributes, default = @default)
       @classifiers = []
-      10.times { @classifiers << Ruleset.new(attributes, data, default, @type) }
+      10.times { @classifiers << RuleSet.new(attributes, data, default, @type) }
       @classifiers.each do |c|
         c.train(data, attributes, default)
       end

--- a/lib/decisiontree/id3_tree.rb
+++ b/lib/decisiontree/id3_tree.rb
@@ -261,7 +261,7 @@ module DecisionTree
   end
 
   class RuleSet
-    attr_accessor :rules
+    attr_accessor :rules, :train_data
 
     def initialize(attributes, data, default, type)
       @attributes = attributes


### PR DESCRIPTION
I need the train data out of the box, so added an attributes accessor to access the train data in RuleSet Class, So that I can get the accuracy directly. For better understanding I can show u the code snippet 

```ruby 
class Simple
  def initialize(attributes=nil, training=nil)
    @attributes = attributes || ['Temperature']
    @training = training ||[
        [36.6, 'healthy'],
        [37, 'sick'],
        [38, 'sick'],
        [36.7, 'healthy'],
        [40, 'sick'],
        [50, 'really sick']
    ]
  end

  def tree
    dec_tree = DecisionTree::ID3Tree.new(@attributes, @training, 'sick', :continuous)
    dec_tree.train
    rule_set = dec_tree.rule_set

    result = rule_set.rules.each { |r| r.accuracy(rule_set.train_data) }
    result.collect { |r| ap [r.conclusion, r.accuracy] }
  end
