### PR TITLE
Improve Graph Output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+*.png

--- a/lib/decisiontree/id3_tree.rb
+++ b/lib/decisiontree/id3_tree.rb
@@ -130,7 +130,13 @@ module DecisionTree
     def graph(filename, file_type = 'png')
       require 'graphr'
       dgp = DotGraphPrinter.new(build_tree)
+      dgp.size = ''
+      dgp.node_labeler = proc { |n| n.split("\n").first }
       dgp.write_to_file("#{filename}.#{file_type}", file_type)
+    rescue LoadError
+      STDERR.puts "Error: Cannot generate graph."
+      STDERR.puts "       The 'graphr' gem doesn't seem to be installed."
+      STDERR.puts "       Run 'gem install graphr' or add it to your Gemfile."
     end
 
     def ruleset
@@ -188,9 +194,11 @@ module DecisionTree
           child = attr[1][key]
           child_text = "#{child}\n(#{child.to_s.clone.object_id})"
         end
-        label_text = "#{key} ''"
+
         if type(attr[0].attribute) == :continuous
-          label_text.gsub!("''", attr[0].threshold.to_s)
+          label_text = "#{key} #{attr[0].threshold}"
+        else
+          label_text = key
         end
 
         [parent_text, child_text, label_text]


### PR DESCRIPTION
This PR comes to fix some obvious issues with the `#graph` method, in the least intrusive way possible, 

### Issue 1: Graph too small

The graph size too small for wide or tall trees - see #29

Fixed by providing an empty size to the `DotGraphPrinter`

### Issue 2: Graphr dependency error

Since the `graphr` gem is not in the dependency list, a non friendly error was thrown when it was not found.

Fixed by rescuing `LoadError` and printing a friendly error message to `STDERR`

### Issue 3: ID in node labels

The node labels included the object ID, which was necessary to distinguish between nodes, but not necessary for viewing. 

Fixed by providing an alternative `node_labeler` proc to the `DotGraphPrinter`

### Issue 4: Empty quotes in discrete labels

In discrete cases, the label included empty `''` - for example, `January ''`. Not sure what it was there for, so I changed it.